### PR TITLE
Minor cleanup

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -21,8 +21,6 @@
  *   ops teams to update code in a central location.
  */
 
-// g3-format-prettier
-
 declare global {
   const LaunchMonitor: Exported;
 }

--- a/common/ads_api.ts
+++ b/common/ads_api.ts
@@ -19,8 +19,6 @@
  * @fileoverview DAO for the Google Ads API and SA360 API
  */
 
-// g3-format-prettier
-
 import * as AdTypes from './ads_api_types';
 
 import URLFetchRequestOptions = GoogleAppsScript.URL_Fetch.URLFetchRequestOptions;

--- a/common/ads_api_types.ts
+++ b/common/ads_api_types.ts
@@ -19,8 +19,6 @@
  * @fileoverview Ads API-specific types for SA360 and Google Ads
  */
 
-// g3-format-prettier
-
 import { BaseClientArgs } from './types';
 
 /**

--- a/common/client_helpers.ts
+++ b/common/client_helpers.ts
@@ -19,8 +19,6 @@
  * @fileoverview Client helpers - frontend agnostic.
  */
 
-// g3-format-prettier
-
 import { transformToParamValues } from './sheet_helpers';
 import {
   BaseClientArgs,

--- a/common/sheet_helpers.ts
+++ b/common/sheet_helpers.ts
@@ -34,7 +34,7 @@ import {
   BaseClientArgs,
   BaseClientInterface,
   ExecutorResult,
-  FrontEndArgs,
+  FrontendArgs,
   ParamDefinition,
   RecordInfo,
   RuleDefinition,
@@ -517,18 +517,18 @@ export function getTemplateSetting(
  * While the default application should cover base needs, customers may want to
  * program custom rules or use Firebase for increased storage space.
  */
-export abstract class AppsScriptFrontEnd<
+export abstract class AppsScriptFrontend<
   C extends BaseClientInterface<C, G, A>,
   G extends RuleGranularity<G>,
   A extends BaseClientArgs,
-  F extends AppsScriptFrontEnd<C, G, A, F>,
+  F extends AppsScriptFrontend<C, G, A, F>,
 > {
   readonly client: C;
   readonly rules: ReadonlyArray<RuleExecutorClass<C, G, A>>;
 
   protected constructor(
     private readonly category: string,
-    private readonly injectedArgs: FrontEndArgs<C, G, A, F>,
+    private readonly injectedArgs: FrontendArgs<C, G, A, F>,
   ) {
     const clientArgs = this.getIdentity();
     if (!clientArgs) {
@@ -749,7 +749,7 @@ export abstract class AppsScriptFrontEnd<
 
   displayGlossary() {
     const template = HtmlService.createTemplateFromFile('html/glossary');
-    template['rules'] = this.getFrontEndDefinitions();
+    template['rules'] = this.getFrontendDefinitions();
     SpreadsheetApp.getUi().showSidebar(template.evaluate());
   }
 
@@ -759,7 +759,7 @@ export abstract class AppsScriptFrontEnd<
     );
   }
 
-  getFrontEndDefinitions() {
+  getFrontendDefinitions() {
     return this.rules.map((rule) => rule.definition);
   }
 
@@ -1272,7 +1272,7 @@ function load<
   C extends BaseClientInterface<C, G, A>,
   G extends RuleGranularity<G>,
   A extends BaseClientArgs,
-  F extends AppsScriptFrontEnd<C, G, A, F>,
+  F extends AppsScriptFrontend<C, G, A, F>,
 >(frontEndCaller: ScriptFunction<F>, fnName: ScriptEntryPoints) {
   return (
     scriptProperties: PropertyStore | GoogleAppsScript.Events.AppsScriptEvent,
@@ -1307,7 +1307,7 @@ function applyBinding<
   C extends BaseClientInterface<C, G, A>,
   G extends RuleGranularity<G>,
   A extends BaseClientArgs,
-  F extends AppsScriptFrontEnd<C, G, A, F>,
+  F extends AppsScriptFrontend<C, G, A, F>,
 >(frontEndCaller: ScriptFunction<F>): ScriptFunction<F> {
   return (scriptProperties: PropertyStore) => {
     const frontend = frontEndCaller(scriptProperties);
@@ -1324,14 +1324,14 @@ function applyBinding<
  * Primary entry point for an Apps Script implementation.
  * @param frontEndCaller A callable that late binds {@link toExport} to the
  *   correct functions from a frontend. A correct implementation of this
- *   function will initialize a {@link AppsScriptFrontEnd} class and assign
+ *   function will initialize a {@link AppsScriptFrontend} class and assign
  *   all functions the first time it's called.
  */
 export function lazyLoadApp<
   C extends BaseClientInterface<C, G, A>,
   G extends RuleGranularity<G>,
   A extends BaseClientArgs,
-  F extends AppsScriptFrontEnd<C, G, A, F>,
+  F extends AppsScriptFrontend<C, G, A, F>,
 >(frontEndCaller: ScriptFunction<F>): ScriptFunction<F> {
   const binders = applyBinding<C, G, A, F>(frontEndCaller);
   toExport.onOpen = load<C, G, A, F>(binders, 'onOpen');

--- a/common/sheet_helpers.ts
+++ b/common/sheet_helpers.ts
@@ -19,8 +19,6 @@
  * @fileoverview Helpers for Apps Script based front-ends.
  */
 
-// g3-format-prettier
-
 import {
   PropertyStore,
   RuleParams,

--- a/common/test_helpers/mock_apps_script.ts
+++ b/common/test_helpers/mock_apps_script.ts
@@ -19,8 +19,6 @@
  * @fileoverview Mocked classes for Apps Script to help with unit tests.
  */
 
-// g3-format-prettier
-
 import { PropertyStore } from 'common/types';
 
 import Properties = GoogleAppsScript.Properties;

--- a/common/tests/api_test.ts
+++ b/common/tests/api_test.ts
@@ -19,8 +19,6 @@
  * @fileoverview Tests for the common API library suites.
  */
 
-// g3-format-prettier
-
 import {
   CredentialManager,
   GET_LEAF_ACCOUNTS_REPORT,

--- a/common/tests/helpers.ts
+++ b/common/tests/helpers.ts
@@ -31,13 +31,13 @@ import {
   GoogleAdsApiFactory,
   ReportFactory,
 } from '../ads_api';
-import { AbstractRuleRange, AppsScriptFrontEnd } from '../sheet_helpers';
+import { AbstractRuleRange, AppsScriptFrontend } from '../sheet_helpers';
 import {
   AppsScriptFunctions,
   BaseClientArgs,
   BaseClientInterface,
   ExecutorResult,
-  FrontEndArgs,
+  FrontendArgs,
   ParamDefinition,
   RecordInfo,
   RuleExecutor,
@@ -150,11 +150,11 @@ export class FakeClient implements TestClientInterface {
 /**
  * A fake frontend for testing.
  */
-export class FakeFrontEnd extends AppsScriptFrontEnd<
+export class FakeFrontend extends AppsScriptFrontend<
   TestClientInterface,
   Granularity,
   BaseClientArgs,
-  FakeFrontEnd
+  FakeFrontend
 > {
   readonly calls: Record<AppsScriptFunctions, number> = {
     onOpen: 0,
@@ -169,11 +169,11 @@ export class FakeFrontEnd extends AppsScriptFrontEnd<
   private readonly old: GoogleAppsScript.Mail.MailAdvancedParameters[] = [];
 
   constructor(
-    args: FrontEndArgs<
+    args: FrontendArgs<
       TestClientInterface,
       Granularity,
       BaseClientArgs,
-      FakeFrontEnd
+      FakeFrontend
     >,
   ) {
     scaffoldSheetWithNamedRanges();

--- a/common/tests/helpers.ts
+++ b/common/tests/helpers.ts
@@ -19,8 +19,6 @@
  * @fileoverview Test helpers for the common library.
  */
 
-// g3-format-prettier
-
 import { AdsClientArgs } from 'common/ads_api_types';
 import { FakePropertyStore } from 'common/test_helpers/mock_apps_script';
 

--- a/common/tests/sheet_helpers_test.ts
+++ b/common/tests/sheet_helpers_test.ts
@@ -45,14 +45,14 @@ import {
 
 import {
   FakeClient,
-  FakeFrontEnd,
+  FakeFrontend,
   Granularity,
   RuleRange,
   TestClientInterface,
 } from './helpers';
 
 describe('Check globals', () => {
-  let frontend: FakeFrontEnd;
+  let frontend: FakeFrontend;
 
   beforeEach(() => {
     setUp();
@@ -60,9 +60,9 @@ describe('Check globals', () => {
       TestClientInterface,
       Granularity,
       BaseClientArgs,
-      FakeFrontEnd
+      FakeFrontend
     >((properties) => {
-      return new FakeFrontEnd({
+      return new FakeFrontend({
         ruleRangeClass: RuleRange,
         rules: [],
         version: '1.0',
@@ -115,7 +115,7 @@ describe('Test migration order', () => {
     '2.2.0': () => list.push('2.2.0'),
   };
 
-  function setFrontEnd({
+  function setFrontend({
     expectedVersion,
     currentVersion,
   }: {
@@ -130,9 +130,9 @@ describe('Test migration order', () => {
       TestClientInterface,
       Granularity,
       BaseClientArgs,
-      FakeFrontEnd
+      FakeFrontend
     >((properties) => {
-      return new FakeFrontEnd({
+      return new FakeFrontend({
         ruleRangeClass: RuleRange,
         rules: [],
         version: expectedVersion,
@@ -152,7 +152,7 @@ describe('Test migration order', () => {
   });
 
   it('migrates all', () => {
-    const frontend = setFrontEnd({
+    const frontend = setFrontend({
       expectedVersion: '5.0',
       currentVersion: '1.0',
     });
@@ -161,7 +161,7 @@ describe('Test migration order', () => {
   });
 
   it('partially migrates', () => {
-    const frontend = setFrontEnd({
+    const frontend = setFrontend({
       expectedVersion: '5.0',
       currentVersion: '2.1.0',
     });
@@ -170,7 +170,7 @@ describe('Test migration order', () => {
   });
 
   it('runs when initializeSheets runs', async () => {
-    const frontend = setFrontEnd({
+    const frontend = setFrontend({
       expectedVersion: CURRENT_SHEET_VERSION,
       currentVersion: '1.0',
     });
@@ -184,7 +184,7 @@ describe('Test migration order', () => {
   });
 
   it('does not run migrations if version is up-to-date', () => {
-    const frontend = setFrontEnd({
+    const frontend = setFrontend({
       expectedVersion: CURRENT_SHEET_VERSION,
       currentVersion: '1.0',
     });
@@ -198,7 +198,7 @@ describe('Test migration order', () => {
   });
 
   it('migrates only to specified version cap', () => {
-    const frontend = setFrontEnd({
+    const frontend = setFrontend({
       expectedVersion: '2.1.0',
       currentVersion: '2.1.0',
     });
@@ -402,7 +402,7 @@ describe('test HELPERS', () => {
 });
 
 describe('Test emails', () => {
-  let frontend: FakeFrontEnd;
+  let frontend: FakeFrontend;
   let rules: Record<string, RuleGetter>;
 
   const email = (to: string) => ({
@@ -480,9 +480,9 @@ describe('Test emails', () => {
       TestClientInterface,
       Granularity,
       BaseClientArgs,
-      FakeFrontEnd
+      FakeFrontend
     >((properties) => {
-      return new FakeFrontEnd({
+      return new FakeFrontend({
         ruleRangeClass: RuleRange,
         rules: [],
         version: '1.0',

--- a/common/tests/sheet_helpers_test.ts
+++ b/common/tests/sheet_helpers_test.ts
@@ -19,8 +19,6 @@
  * @fileoverview Tests for sheet helpers.
  */
 
-// g3-format-prettier
-
 import {
   FakePropertyStore,
   mockAppsScript,

--- a/common/types.ts
+++ b/common/types.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// g3-format-prettier
-
 import { AppsScriptFrontend } from './sheet_helpers';
 
 /**

--- a/common/types.ts
+++ b/common/types.ts
@@ -17,7 +17,7 @@
 
 // g3-format-prettier
 
-import { AppsScriptFrontEnd } from './sheet_helpers';
+import { AppsScriptFrontend } from './sheet_helpers';
 
 /**
  * An abstraction for retrieving properties.
@@ -302,11 +302,11 @@ export interface RuleRangeInterface<
  * This is used to inject arguments into implementations, which determines
  * how the client gets executed.
  */
-export interface FrontEndArgs<
+export interface FrontendArgs<
   C extends BaseClientInterface<C, G, A>,
   G extends RuleGranularity<G>,
   A extends BaseClientArgs,
-  F extends AppsScriptFrontEnd<C, G, A, F>,
+  F extends AppsScriptFrontend<C, G, A, F>,
 > {
   readonly ruleRangeClass: {
     new (sheet: string[][], client: C): RuleRangeInterface<C, G, A>;

--- a/dv360/src/api.ts
+++ b/dv360/src/api.ts
@@ -19,8 +19,6 @@
  * @fileoverview Contains a DAO for DBM access.
  */
 
-// g3-format-prettier
-
 import { IDType, QueryReportParams } from './types';
 
 /** The API version to use. Exposed for testing. */

--- a/dv360/src/client.ts
+++ b/dv360/src/client.ts
@@ -19,8 +19,6 @@
  * @fileoverview Client class for DV360.
  */
 
-// g3-format-prettier
-
 import {
   Advertisers,
   AssignedTargetingOptions,

--- a/dv360/src/frontend.ts
+++ b/dv360/src/frontend.ts
@@ -22,14 +22,14 @@
 // g3-format-prettier
 
 import {
-  AppsScriptFrontEnd,
+  AppsScriptFrontend,
   AppsScriptPropertyStore,
   HELPERS,
   LABEL_RANGE,
   addSettingWithDescription,
   getOrCreateSheet,
 } from 'common/sheet_helpers';
-import { FrontEndArgs } from 'common/types';
+import { FrontendArgs } from 'common/types';
 import { RuleRange } from 'dv360/src/client';
 import { ClientArgs, ClientInterface } from 'dv360/src/types';
 
@@ -49,7 +49,7 @@ export const GENERAL_SETTINGS_SHEET = 'General/Settings';
  */
 export const migrations: Record<
   string,
-  (frontend: DisplayVideoFrontEnd) => void
+  (frontend: DisplayVideoFrontend) => void
 > = {
   '1.1': (frontend) => {
     const active = SpreadsheetApp.getActive();
@@ -132,18 +132,18 @@ export const migrations: Record<
 /**
  * Front-end configuration for DV360 Apps Script.
  */
-export class DisplayVideoFrontEnd extends AppsScriptFrontEnd<
+export class DisplayVideoFrontend extends AppsScriptFrontend<
   ClientInterface,
   RuleGranularity,
   ClientArgs,
-  DisplayVideoFrontEnd
+  DisplayVideoFrontend
 > {
   constructor(
-    args: FrontEndArgs<
+    args: FrontendArgs<
       ClientInterface,
       RuleGranularity,
       ClientArgs,
-      DisplayVideoFrontEnd
+      DisplayVideoFrontend
     >,
   ) {
     super('DV360', args);

--- a/dv360/src/frontend.ts
+++ b/dv360/src/frontend.ts
@@ -19,8 +19,6 @@
  * @fileoverview frontend/apps script hooks for DV360 launch monitor
  */
 
-// g3-format-prettier
-
 import {
   AppsScriptFrontend,
   AppsScriptPropertyStore,

--- a/dv360/src/main.ts
+++ b/dv360/src/main.ts
@@ -19,8 +19,6 @@
  * @fileoverview Apps Script handlers.
  */
 
-// g3-format-prettier
-
 import { lazyLoadApp, toExport } from 'common/sheet_helpers';
 import { PropertyStore } from 'common/types';
 

--- a/dv360/src/main.ts
+++ b/dv360/src/main.ts
@@ -25,7 +25,7 @@ import { lazyLoadApp, toExport } from 'common/sheet_helpers';
 import { PropertyStore } from 'common/types';
 
 import { Client, RuleRange } from './client';
-import { DisplayVideoFrontEnd, migrations } from './frontend';
+import { DisplayVideoFrontend, migrations } from './frontend';
 import {
   budgetPacingDaysAheadRule,
   budgetPacingPercentageRule,
@@ -48,8 +48,8 @@ export const CURRENT_SHEET_VERSION = '1.5';
  *
  * Broken out for testability.
  */
-export function getFrontEnd(properties: PropertyStore) {
-  return new DisplayVideoFrontEnd({
+export function getFrontend(properties: PropertyStore) {
+  return new DisplayVideoFrontend({
     ruleRangeClass: RuleRange,
     rules: [
       budgetPacingDaysAheadRule,
@@ -72,8 +72,8 @@ export function getFrontEnd(properties: PropertyStore) {
  *
  * Exported for testing.
  */
-lazyLoadApp<ClientInterface, RuleGranularity, ClientArgs, DisplayVideoFrontEnd>(
-  getFrontEnd,
+lazyLoadApp<ClientInterface, RuleGranularity, ClientArgs, DisplayVideoFrontend>(
+  getFrontend,
 );
 
 global.onOpen = toExport.onOpen;

--- a/dv360/src/rule_types.ts
+++ b/dv360/src/rule_types.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// g3-format-prettier
-
 interface BudgetPacing {
   startDate: Readonly<Date>;
   endDate: Readonly<Date>;

--- a/dv360/src/rules.ts
+++ b/dv360/src/rules.ts
@@ -19,8 +19,6 @@
  * @fileoverview Contains rules tailored for the current client.
  */
 
-// g3-format-prettier
-
 import {
   AssignedTargetingOption,
   InsertionOrder,

--- a/dv360/src/tests/client_helpers.ts
+++ b/dv360/src/tests/client_helpers.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// g3-format-prettier
-
 import {
   AssignedTargetingOptions,
   Campaigns,

--- a/dv360/src/tests/client_test.ts
+++ b/dv360/src/tests/client_test.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// g3-format-prettier
-
 import { equalTo } from 'common/checks';
 import { mockAppsScript } from 'common/test_helpers/mock_apps_script';
 import { Value } from 'common/types';

--- a/dv360/src/tests/dbm_test.ts
+++ b/dv360/src/tests/dbm_test.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// g3-format-prettier
-
 import { mockAppsScript } from 'common/test_helpers/mock_apps_script';
 
 import { BudgetReport, ImpressionReport } from '../api';

--- a/dv360/src/tests/dbm_test_helpers.ts
+++ b/dv360/src/tests/dbm_test_helpers.ts
@@ -20,8 +20,6 @@
  *
  */
 
-// g3-format-prettier
-
 import { DBM_API_VERSION, DBM_URL } from '../api';
 
 interface Params {

--- a/dv360/src/tests/rules_test.ts
+++ b/dv360/src/tests/rules_test.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// g3-format-prettier
-
 import { AssignedTargetingOption } from 'dv360_api/dv360_resources';
 import { ApiDate, TARGETING_TYPE } from 'dv360_api/dv360_types';
 import { AppsScriptPropertyStore } from 'common/sheet_helpers';

--- a/dv360/src/tests/utils_test.ts
+++ b/dv360/src/tests/utils_test.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// g3-format-prettier
-
 import { SettingMap, transformToParamValues } from 'common/sheet_helpers';
 import { RuleRange, getDate } from '../client';
 

--- a/dv360/src/types.ts
+++ b/dv360/src/types.ts
@@ -19,8 +19,6 @@
  * @fileoverview Types for DV360
  */
 
-// g3-format-prettier
-
 import {
   Advertisers,
   AssignedTargetingOptions,

--- a/googleads/old/src/types.ts
+++ b/googleads/old/src/types.ts
@@ -19,8 +19,6 @@
  * @fileoverview Google Ads-specific interfaces.
  */
 
-// g3-format-prettier
-
 import { AdsClientArgs } from 'common/ads_api_types';
 import { BaseClientInterface } from 'common/types';
 

--- a/sa360/src/api.ts
+++ b/sa360/src/api.ts
@@ -19,8 +19,6 @@
  * @fileoverview DAO for the SA360 Reporting API
  */
 
-// g3-format-prettier
-
 import { HELPERS } from 'common/sheet_helpers';
 import { RecordInfo } from 'common/types';
 import { SearchAdsTimeRange } from 'sa360/src/types';

--- a/sa360/src/frontend.ts
+++ b/sa360/src/frontend.ts
@@ -19,8 +19,6 @@
  * @fileoverview frontend/apps script hooks for SA360 launch monitor
  */
 
-// g3-format-prettier
-
 import {
   AppsScriptFrontend,
   AppsScriptPropertyStore,

--- a/sa360/src/frontend.ts
+++ b/sa360/src/frontend.ts
@@ -22,14 +22,14 @@
 // g3-format-prettier
 
 import {
-  AppsScriptFrontEnd,
+  AppsScriptFrontend,
   AppsScriptPropertyStore,
   RULE_SETTINGS_SHEET,
   addSettingWithDescription,
   getOrCreateSheet,
   getTemplateSetting,
 } from 'common/sheet_helpers';
-import { FrontEndArgs, ParamDefinition, RuleExecutor } from 'common/types';
+import { FrontendArgs, ParamDefinition, RuleExecutor } from 'common/types';
 import { RuleRange } from 'sa360/src/client';
 import {
   ClientArgs,
@@ -70,7 +70,7 @@ const FULL_FETCH_RANGE = 'FULL_FETCH';
  * A list of migrations with version as key and a migration script as the
  * value.
  */
-export const migrations: Record<string, (frontend: SearchAdsFrontEnd) => void> =
+export const migrations: Record<string, (frontend: SearchAdsFrontend) => void> =
   {
     '1.1': (frontend) => {
       const active = SpreadsheetApp.getActive();
@@ -236,24 +236,24 @@ export const migrations: Record<string, (frontend: SearchAdsFrontEnd) => void> =
  */
 export const migrationsV2: Record<
   string,
-  (frontend: NewSearchAdsFrontEnd) => void
+  (frontend: NewSearchAdsFrontend) => void
 > = {};
 
 /**
  * Front-end configuration for SA360 Apps Script.
  */
-export class SearchAdsFrontEnd extends AppsScriptFrontEnd<
+export class SearchAdsFrontend extends AppsScriptFrontend<
   ClientInterface,
   RuleGranularity,
   ClientArgs,
-  SearchAdsFrontEnd
+  SearchAdsFrontend
 > {
   constructor(
-    args: FrontEndArgs<
+    args: FrontendArgs<
       ClientInterface,
       RuleGranularity,
       ClientArgs,
-      SearchAdsFrontEnd
+      SearchAdsFrontend
     >,
   ) {
     super('SA360', args);
@@ -319,18 +319,18 @@ export class SearchAdsFrontEnd extends AppsScriptFrontEnd<
 /**
  * Front-end configuration for the new SA360 (our V2) Apps Script.
  */
-export class NewSearchAdsFrontEnd extends AppsScriptFrontEnd<
+export class NewSearchAdsFrontend extends AppsScriptFrontend<
   ClientInterfaceV2,
   RuleGranularity,
   ClientArgsV2,
-  NewSearchAdsFrontEnd
+  NewSearchAdsFrontend
 > {
   constructor(
-    args: FrontEndArgs<
+    args: FrontendArgs<
       ClientInterfaceV2,
       RuleGranularity,
       ClientArgsV2,
-      NewSearchAdsFrontEnd
+      NewSearchAdsFrontend
     >,
   ) {
     super('SA360', args);

--- a/sa360/src/main.ts
+++ b/sa360/src/main.ts
@@ -36,7 +36,7 @@ import { lazyLoadApp, toExport } from 'common/sheet_helpers';
 import { PropertyStore } from 'common/types';
 import { ClientV2, RuleRangeV2 } from 'sa360/src/client';
 
-import { migrationsV2, NewSearchAdsFrontEnd } from './frontend';
+import { migrationsV2, NewSearchAdsFrontend } from './frontend';
 import { ClientArgsV2, ClientInterfaceV2, RuleGranularity } from './types';
 
 /**
@@ -50,8 +50,8 @@ export const CURRENT_SHEET_VERSION = '2.0';
 /**
  * Generate a front-end object for lazy loading.
  */
-export function getFrontEnd(properties: PropertyStore) {
-  return new NewSearchAdsFrontEnd({
+export function getFrontend(properties: PropertyStore) {
+  return new NewSearchAdsFrontend({
     ruleRangeClass: RuleRangeV2,
     rules: [],
     version: CURRENT_SHEET_VERSION,
@@ -73,8 +73,8 @@ lazyLoadApp<
   ClientInterfaceV2,
   RuleGranularity,
   ClientArgsV2,
-  NewSearchAdsFrontEnd
->(getFrontEnd);
+  NewSearchAdsFrontend
+>(getFrontend);
 
 global.onOpen = toExport.onOpen;
 global.initializeSheets = toExport.initializeSheets;

--- a/sa360/src/main.ts
+++ b/sa360/src/main.ts
@@ -24,8 +24,6 @@
  * END-INTERNAL
  */
 
-// g3-format-prettier
-
 import {
   CredentialManager,
   GoogleAdsApiFactory,

--- a/sa360/src/tests/api_test.ts
+++ b/sa360/src/tests/api_test.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// g3-format-prettier
-
 import { AppsScriptPropertyStore } from 'common/sheet_helpers';
 import { mockAppsScript } from 'common/test_helpers/mock_apps_script';
 import * as api from 'sa360/src/api';

--- a/sa360/src/tests/client_helpers.ts
+++ b/sa360/src/tests/client_helpers.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// g3-format-prettier
-
 import { PropertyStore } from 'common/types';
 import {
   adGroupColumns,

--- a/sa360/src/tests/match_table.ts
+++ b/sa360/src/tests/match_table.ts
@@ -20,8 +20,6 @@
  *
  */
 
-// g3-format-prettier
-
 import { SA360_API_VERSION, SA360_URL } from 'sa360/src/api';
 
 interface Params {

--- a/sa360/src/types.ts
+++ b/sa360/src/types.ts
@@ -19,8 +19,6 @@
  * @fileoverview types for Google Ads
  */
 
-// g3-format-prettier
-
 import * as AdTypes from 'common/ads_api_types';
 import { AdsClientArgs } from 'common/ads_api_types';
 


### PR DESCRIPTION
- Remove all references to //g3-format-prettier, as they are not needed.
- Rename FrontEnd to Frontend as it's typically considered one word.
