### PR TITLE
Fix Geotargeting rule

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,6 +3,5 @@
 
 yarn
 yarn playwright install
-yarn test
 yarn lint-staged
 npx tsc -p .

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,4 +4,5 @@
 yarn
 yarn playwright install
 yarn lint-staged
+yarn test
 npx tsc -p .

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,6 +1,5 @@
 {
   "**/*.{ts, js}": [
     "npx prettier --write .",
-    "yarn test"
   ]
 }

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,3 +1,6 @@
 {
-  "*.{ts, js}": "npx prettier --write ."
+  "**/*.{ts, js}": [
+    "npx prettier --write .",
+    "yarn test"
+  ]
 }

--- a/sa360/src/rules.ts
+++ b/sa360/src/rules.ts
@@ -386,12 +386,13 @@ export const geoTargetRule = newRule({
   params: {
     criteriaIds: {
       label: 'Criteria IDs',
+      numberFormat: '0',
     },
   },
   defaults: {
     criteriaIds: '',
   },
-  granularity: RuleGranularity.AD_GROUP,
+  granularity: RuleGranularity.CAMPAIGN,
   helper: `=HYPERLINK(
     "https://developers.google.com/google-ads/api/reference/data/geotargets", "Refer to the Criteria ID found in this report.")`,
   valueFormat: { label: 'Change' },
@@ -404,14 +405,16 @@ export const geoTargetRule = newRule({
     for (const [campaignId, [targets, fields]] of Object.entries(
       aggregatedReport,
     )) {
-      const setting = this.settings.get(campaignId).criteriaIds.split(',');
+      const setting = String(this.settings.get(campaignId).criteriaIds).split(
+        /[;,]/g,
+      );
 
       values[campaignId] = trackSettingsChanges({
         stored: setting,
         targets,
         fields,
       });
-      this.settings.set(campaignId, { criteriaIds: setting.join(',') });
+      this.settings.set(campaignId, { criteriaIds: "'" + setting.join(';') });
     }
     return { values };
   },

--- a/sa360/src/rules.ts
+++ b/sa360/src/rules.ts
@@ -414,7 +414,7 @@ export const geoTargetRule = newRule({
         targets,
         fields,
       });
-      this.settings.set(campaignId, { criteriaIds: "'" + setting.join(';') });
+      this.settings.set(campaignId, { criteriaIds: setting.join(';') });
     }
     return { values };
   },


### PR DESCRIPTION
Two issues were found with the geotarget rule:

1. It was being sent to ad groups instead of campaigns which prevented it from mapping to the right settings.
2. The criteria IDs are numbers and Google Sheets was interpreting them as long numbers. Now we use semicolons
   to split up everything in order to make it clearer that these aren't numbers. It's forward compatible, so
   existing strings will still be split.
