### PR TITLE
Feature Omnibus

### DIFF
--- a/common/sheet_helpers.ts
+++ b/common/sheet_helpers.ts
@@ -237,11 +237,13 @@ export abstract class AbstractRuleRange<T extends ClientTypes<T>>
 
   getValues(ruleGranularity?: T['ruleGranularity']): string[][] {
     const newRowIndex = { ...this.rowIndex };
-    const defaultFirstColumns = ['', ''];
 
     const values = Object.entries(this.rules).reduce(
       (combinedRuleRange, [category, rangeRaw]) => {
         const range = rangeRaw.filter((row) => row && row.length);
+        const defaultFirstColumns = Array.from<string>({
+          length: range[0].length,
+        }).fill('');
         if (
           ruleGranularity &&
           this.client.ruleStore[category] &&
@@ -269,7 +271,7 @@ export abstract class AbstractRuleRange<T extends ClientTypes<T>>
             : combinedRuleRange[1].concat(
                 Array.from<string>({ length: ruleSettingColumnCount })
                   .fill('')
-                  .map((cell, idx) => {
+                  .map((_cell, idx) => {
                     if (
                       idx === 0 &&
                       this.client.ruleStore[
@@ -996,7 +998,7 @@ export abstract class AppsScriptFrontend<T extends ClientTypes<T>> {
     );
 
     for (const [version, migration] of migrations) {
-      if (sortMigrations(version, this.injectedArgs.version) >= 0) {
+      if (sortMigrations(sheetVersion, this.injectedArgs.version) >= 0) {
         break;
       }
       if (sortMigrations(version, sheetVersion) > 0) {

--- a/common/types.ts
+++ b/common/types.ts
@@ -162,6 +162,7 @@ export interface RuleDefinition<
  */
 export interface RecordInfo {
   advertiserId: string;
+  advertiserName?: string;
   id: string;
   displayName: string;
 }

--- a/dv360/appsscript.json
+++ b/dv360/appsscript.json
@@ -17,7 +17,8 @@
     "https://www.googleapis.com/auth/drive.file",
     "https://www.googleapis.com/auth/drive.readonly",
     "https://www.googleapis.com/auth/adwords",
-    "https://www.googleapis.com/auth/script.container.ui"
+    "https://www.googleapis.com/auth/script.container.ui",
+    "https://www.googleapis.com/auth/script.send_mail"
   ],
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8"

--- a/dv360/src/frontend.ts
+++ b/dv360/src/frontend.ts
@@ -119,20 +119,7 @@ export const migrations: Record<
       "The ID of the Drive folder destination\n(copy in folder URL after '/folders/' and before the '?')",
     ]);
   },
-  '2.0': () => {
-    const properties = new AppsScriptPropertyStore();
-    Object.entries(properties.getProperties()).forEach(([k, v]) => {
-      const values = JSON.parse(v);
-      if (values.updated) {
-        return;
-      }
-      properties.setProperty(
-        k,
-        JSON.stringify({ values, updated: new Date() }),
-      );
-    });
-  },
-  '3.0': (frontend) => {
+  '2.1': (frontend) => {
     const sheet = getOrCreateSheet('Rule Settings - Campaign');
     const ruleRange = new RuleRange(
       sheet.getDataRange().getValues(),

--- a/dv360/src/frontend.ts
+++ b/dv360/src/frontend.ts
@@ -132,6 +132,21 @@ export const migrations: Record<
       );
     });
   },
+  '3.0': (frontend) => {
+    const sheet = getOrCreateSheet('Rule Settings - Campaign');
+    const ruleRange = new RuleRange(
+      sheet.getDataRange().getValues(),
+      frontend.client,
+    );
+    const values = ruleRange.getValues();
+    const headers = values[2];
+    const geoTargetIndex = headers.findIndex((c) => c === 'Geo Targets');
+    if (geoTargetIndex === -1) {
+      return;
+    }
+    headers[geoTargetIndex] = 'Allowed Geo Targets';
+    sheet.getRange(1, 1, values.length, values[0].length).setValues(values);
+  },
 };
 
 /**

--- a/dv360/src/main.ts
+++ b/dv360/src/main.ts
@@ -67,24 +67,24 @@ export function getFrontend(
   });
 }
 
-function onOpen(properties = new AppsScriptPropertyStore()) {
-  getFrontend(properties).onOpen();
+async function onOpen(properties = new AppsScriptPropertyStore()) {
+  await getFrontend(properties).onOpen();
 }
 
-function initializeSheets(properties = new AppsScriptPropertyStore()) {
-  getFrontend(properties).initializeSheets();
+async function initializeSheets(properties = new AppsScriptPropertyStore()) {
+  await getFrontend(properties).initializeSheets();
 }
 
-function initializeRules(properties = new AppsScriptPropertyStore()) {
-  getFrontend(properties).initializeRules();
+async function initializeRules(properties = new AppsScriptPropertyStore()) {
+  await getFrontend(properties).initializeRules();
 }
 
-function preLaunchQa(properties = new AppsScriptPropertyStore()) {
-  getFrontend(properties).preLaunchQa();
+async function preLaunchQa(properties = new AppsScriptPropertyStore()) {
+  await getFrontend(properties).preLaunchQa();
 }
 
-function launchMonitor(properties = new AppsScriptPropertyStore()) {
-  getFrontend(properties).launchMonitor();
+async function launchMonitor(properties = new AppsScriptPropertyStore()) {
+  await getFrontend(properties).launchMonitor();
 }
 
 global.onOpen = onOpen;

--- a/dv360/src/main.ts
+++ b/dv360/src/main.ts
@@ -38,7 +38,7 @@ import { AppsScriptPropertyStore } from 'common/sheet_helpers';
  * This is used to manage migrations from one version of Launch Monitor to
  * another.
  */
-export const CURRENT_SHEET_VERSION = '1.5';
+export const CURRENT_SHEET_VERSION = '3';
 
 /**
  * Retrieves the front-end as a function.

--- a/dv360/src/main.ts
+++ b/dv360/src/main.ts
@@ -38,7 +38,7 @@ import { AppsScriptPropertyStore } from 'common/sheet_helpers';
  * This is used to manage migrations from one version of Launch Monitor to
  * another.
  */
-export const CURRENT_SHEET_VERSION = '3';
+export const CURRENT_SHEET_VERSION = '2.1';
 
 /**
  * Retrieves the front-end as a function.

--- a/dv360/src/rules.ts
+++ b/dv360/src/rules.ts
@@ -118,7 +118,6 @@ export const geoTargetRule = newRule({
           advertiserId,
           { campaignId: id },
         );
-      let hasOnlyValidGeo = true;
       const campaignSettings = this.settings.getOrDefault(id);
 
       let targetingOptionsLength = 0;

--- a/dv360/src/rules.ts
+++ b/dv360/src/rules.ts
@@ -83,19 +83,24 @@ export const geoTargetRule = newRule({
   helper: `=HYPERLINK(
     "https://developers.google.com/google-ads/api/reference/data/geotargets", "Separate values with commas. Partial match any canonical name linked.")`,
   params: {
-    geotargeting: {
-      label: 'Geo Targets',
+    allowedTargets: {
+      label: 'Allowed Geo Targets',
       validationFormulas: [
         '=REGEXMATCH(INDIRECT(ADDRESS(ROW(), COLUMN())), "^[a-zA-Z ]+(,\\s*[a-zA-Z ]+)?$")',
       ],
       defaultValue: 'United States',
     },
-    excludes: {
+    requiredTargets: {
+      label: 'Required Geo Targets',
+      validationFormulas: [
+        '=REGEXMATCH(INDIRECT(ADDRESS(ROW(), COLUMN())), "^[a-zA-Z ]+(,\\s*[a-zA-Z ]+)?$")',
+      ],
+    },
+    excludedTargets: {
       label: 'Excluded Geo Targets',
       validationFormulas: [
         '=REGEXMATCH(INDIRECT(ADDRESS(ROW(), COLUMN())), "^[a-zA-Z ]+(,\\s*[a-zA-Z ]+)?$")',
       ],
-      defaultValue: '',
     },
   },
   granularity: RuleGranularity.CAMPAIGN,
@@ -118,39 +123,80 @@ export const geoTargetRule = newRule({
 
       let targetingOptionsLength = 0;
 
+      function splitTarget(campaignSetting: string) {
+        return campaignSetting
+          ? campaignSetting.split(',').map((country: string) => country.trim())
+          : [];
+      }
+      const allowedTargets = splitTarget(campaignSettings.allowedTargets);
+      const requiredTargets = splitTarget(campaignSettings.requiredTargets);
+      const excludedTargets = splitTarget(campaignSettings.excludedTargets);
+      const errors: string[] = [];
+      const foundRequiredIndexes = new Set<number>();
+
       targetingOptionApi.list((targetingOptions: AssignedTargetingOption[]) => {
-        function hasAllowedGeo(targetingOption: AssignedTargetingOption) {
-          const displayName = targetingOption.getDisplayName();
-          if (!displayName) {
-            throw new Error('Missing display name');
+        for (const targetingOption of targetingOptions) {
+          if (!targetingOption) {
+            continue;
           }
-          const geoTargets = campaignSettings.geotargeting
-            .split(',')
-            .map((country: string) => country.trim());
-          const excludes = campaignSettings.excludes
-            .split(',')
-            .map((country: string) => country.trim());
-
+          const targetName = targetingOption.getDisplayName();
           if (targetingOption.getTargetingDetails()['negative']) {
-            return !excludes.some(
-              (geoTarget: string) => displayName.indexOf(geoTarget) >= 0,
+            const exclude = excludedTargets.filter(
+              (exc) => targetName.indexOf(exc) >= 0,
             );
+            if (exclude.length) {
+              errors.push(`"${targetName}" found and is an excluded target`);
+            }
+            continue;
           }
-          return geoTargets.some(
-            (geoTarget: string) => displayName.indexOf(geoTarget) >= 0,
-          );
-        }
 
-        // Don't accidentally overwrite hasOnlyValidGeo if it's been set to
-        // false.
-        if (hasOnlyValidGeo) {
-          hasOnlyValidGeo = Boolean(
-            targetingOptions.length && targetingOptions.every(hasAllowedGeo),
+          // find any values not listed in allowedTargets
+          const allowed = allowedTargets.filter(
+            (allowed) => targetName.indexOf(allowed) >= 0,
           );
+          if (allowed.length === 0) {
+            errors.push(`"${targetName}" not an allowed target`);
+          }
+
+          if (requiredTargets.length) {
+            const foundRequiredIndex = requiredTargets.findIndex(
+              (req) => targetName.indexOf(req) >= 0,
+            );
+            if (foundRequiredIndex >= 0) {
+              foundRequiredIndexes.add(foundRequiredIndex);
+            }
+          }
         }
         targetingOptionsLength += targetingOptions.length;
       });
-      values[id] = equalTo(1, hasOnlyValidGeo ? 1 : 0, {
+
+      if (requiredTargets.length) {
+        const missingRequiredTargets = requiredTargets.filter(
+          (_, ix) => !foundRequiredIndexes.has(ix),
+        );
+        errors.push(
+          ...missingRequiredTargets.map(
+            (req) => `"${req}" was required but not targeted`,
+          ),
+        );
+      }
+
+      const errorMessage = (() => {
+        if (errors.length) {
+          return errors.join(',');
+        }
+        if (
+          !targetingOptionsLength &&
+          (requiredTargets.length ||
+            allowedTargets.length ||
+            excludedTargets.length)
+        ) {
+          return 'No targeting set';
+        }
+
+        return 'OK';
+      })();
+      values[id] = equalTo('OK', errorMessage, {
         'Advertiser ID': advertiserId,
         'Campaign Name': displayName,
         'Campaign ID': id,

--- a/dv360/src/tests/client_helpers.ts
+++ b/dv360/src/tests/client_helpers.ts
@@ -38,12 +38,10 @@ import {
   LINE_ITEM_TYPE,
   LineItemBudget,
   LineItemFlight,
-  LineItemPartnerRevenueModel,
   LineItemType,
   PACING_PERIOD,
   Pacing,
   PacingType,
-  PerformanceGoal,
 } from 'dv360_api/dv360_types';
 import { FilterExpression } from 'dv360_api/utils';
 import { FakePropertyStore } from 'common/test_helpers/mock_apps_script';
@@ -328,27 +326,17 @@ export function generateTestClient(param: TestClientParams) {
         );
       }
     }
-    class FakeLineItemBudgetReport extends LineItemBudgetReport {
-      protected override getReport() {
-        return {};
-      }
-
-      override getSpendForLineItem(lineItemId: string): number {
-        return param.fakeSpendAmount;
-      }
-    }
     accessors.lineItems = FakeLineItems;
     if (param.fakeSpendAmount) {
-      class FakeBudgetReport extends BudgetReport {
+      class FakeLineItemBudgetReport extends LineItemBudgetReport {
         protected override getReport() {
           return {};
         }
 
-        override getSpendForInsertionOrder() {
-          return param.fakeSpendAmount!;
+        override getSpendForLineItem(): number {
+          return param.fakeSpendAmount;
         }
       }
-
       accessors.lineItemBudgetReport = FakeLineItemBudgetReport;
     }
   }

--- a/dv360/src/tests/client_test.ts
+++ b/dv360/src/tests/client_test.ts
@@ -46,7 +46,7 @@ describe('Client rules are validated', () => {
         params: {},
         valueFormat: { label: 'Some Value' },
         name: 'ruleA',
-        description: ``,
+        description: '',
         granularity: RuleGranularity.CAMPAIGN,
         async callback() {
           output.push('ruleA');
@@ -60,7 +60,7 @@ describe('Client rules are validated', () => {
         params: {},
         valueFormat: { label: 'Some Value' },
         name: 'ruleB',
-        description: ``,
+        description: '',
         granularity: RuleGranularity.CAMPAIGN,
         async callback() {
           output.push('ruleB');

--- a/dv360/src/tests/frontend_test.ts
+++ b/dv360/src/tests/frontend_test.ts
@@ -1,0 +1,531 @@
+/**
+ * @fileoverview Tests the Apps Script main functions.
+ */
+
+// g3-format-prettier
+
+import { TARGETING_TYPE } from 'dv360_api/dv360_types';
+import { equalTo } from 'common/checks';
+import {
+  getOrCreateSheet,
+  HELPERS,
+  RULE_SETTINGS_SHEET,
+} from 'common/sheet_helpers';
+import {
+  FakeHtmlOutput,
+  FakePropertyStore,
+  mockAppsScript,
+} from 'common/test_helpers/mock_apps_script';
+import { PropertyStore } from 'common/types';
+
+import { Client, RuleRange } from '../client';
+import { DisplayVideoFrontend, migrations } from '../frontend';
+import { budgetPacingPercentageRule, geoTargetRule } from '../rules';
+import { ClientArgs, ClientInterface, IDType } from '../types';
+
+import {
+  AdvertiserTemplateConverter,
+  CampaignTemplateConverter,
+  generateTestClient,
+  InsertionOrderTemplateConverter,
+} from './client_helpers';
+
+import HtmlTemplate = GoogleAppsScript.HTML.HtmlTemplate;
+import { AssignedTargetingOption } from 'dv360_api/dv360_resources';
+
+const FOLDER = 'application/vnd.google-apps.folder';
+
+describe('Rule value filling', () => {
+  let client: Client;
+  let rules: RuleRange;
+
+  const allCampaigns: Record<string, CampaignTemplateConverter[]> = {};
+  const allInsertionOrders: Record<string, InsertionOrderTemplateConverter[]> =
+    {};
+
+  beforeEach(async () => {
+    client = testData({ allCampaigns, allInsertionOrders });
+
+    setUp();
+
+    rules = new RuleRange([[]], client);
+    jasmine.clock().install().mockDate(new Date('1970-03-01'));
+    testData({});
+    await rules.fillRuleValues(geoTargetRule.definition);
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
+  it('uses existing settings when adding new campaigns', async () => {
+    rules.setRule('none', [
+      ['ID', 'ID', 'Campaign Name'],
+      ['c1', 'c1', 'Campaign 1'],
+    ]);
+    rules.setRule(geoTargetRule.definition.name, [
+      [
+        'ID',
+        'Allowed Geo Targets',
+        'Required Geo Targets',
+        'Excluded Geo Targets',
+      ],
+      ['default', '', 'New Jersey', ''],
+      ['c1', 'United States', '', ''],
+    ]);
+
+    allCampaigns['1'].push((campaignTemplate) => {
+      campaignTemplate.id = 'c2';
+      campaignTemplate.displayName = 'Campaign 2';
+
+      return campaignTemplate;
+    });
+
+    allInsertionOrders['1'].push((insertionOrderTemplate) => {
+      insertionOrderTemplate.id = 'io2';
+      insertionOrderTemplate.displayName = 'IO 2';
+      insertionOrderTemplate.campaignId = 'c2';
+      return insertionOrderTemplate;
+    });
+
+    (client as unknown as { storedCampaigns: [] }).storedCampaigns = [];
+    (client as unknown as { storedInsertionOrders: [] }).storedInsertionOrders =
+      [];
+
+    await rules.fillRuleValues(geoTargetRule.definition);
+    expect(rules.getRule(geoTargetRule.definition.name)).toEqual([
+      [
+        'ID',
+        'Allowed Geo Targets',
+        'Required Geo Targets',
+        'Excluded Geo Targets',
+      ],
+      ['default', '', 'New Jersey', ''],
+      ['c1', 'United States', '', ''],
+      ['c2', '', '', ''],
+    ]);
+  });
+});
+
+describe('Pre-Launch QA menu option', () => {
+  let frontend: DisplayVideoFrontend;
+
+  beforeEach(async () => {
+    setUp();
+    frontend = getFrontend(() => testData({}));
+    HtmlService.createTemplateFromFile = () =>
+      ({ evaluate: () => new FakeHtmlOutput() }) as unknown as HtmlTemplate;
+    // force private methods to be visible, so we can manipulate them.
+    await frontend.initializeRules();
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date(Date.UTC(1970, 0, 1)));
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
+  it('clears check results that were previously set', async () => {
+    const noise = Array.from<string>({ length: 10 })
+      .fill('')
+      .map(() => Array.from<string>({ length: 10 }).fill('lorem ipsum'));
+    await frontend.preLaunchQa();
+
+    const sheet = SpreadsheetApp.getActive().getSheetByName(
+      'Pre-Launch QA Results',
+    )!;
+    sheet.getRange(1, 1, noise.length, noise[0].length).setValues(noise);
+    const origValues = sheet.getDataRange().getValues();
+    // try again
+    await frontend.preLaunchQa();
+
+    expect(origValues[9][9]).toEqual('lorem ipsum');
+    expect(sheet.getDataRange().getValues()).toContain([
+      'Geo Targeting',
+      'Advertiser ID: 1, Campaign Name: Campaign 1, Campaign ID: c1, Number of Geos: 1',
+      'OK',
+      'false',
+    ]);
+  });
+});
+
+function getFrontend(
+  overrides: (client: ClientInterface) => ClientInterface = (client) => client,
+  properties: PropertyStore = new FakePropertyStore(),
+) {
+  return new DisplayVideoFrontend({
+    ruleRangeClass: RuleRange,
+    rules: [geoTargetRule, budgetPacingPercentageRule],
+    version: '3.0',
+    clientInitializer(clientArgs, properties) {
+      const client = new Client(clientArgs, properties);
+      return overrides(client);
+    },
+    migrations,
+    properties,
+  });
+}
+
+function testData(params: {
+  allAdvertisers?: AdvertiserTemplateConverter[];
+  allInsertionOrders?: Record<string, InsertionOrderTemplateConverter[]>;
+  allCampaigns?: Record<string, CampaignTemplateConverter[]>;
+  fakeImpressionAmount?: number;
+  fakeSpendAmount?: number;
+  idType?: IDType;
+}) {
+  const id = '1';
+  const allAssignedTargetingOptions = {
+    [id]: {
+      ['c1']: ['United States'].map(
+        (geoTarget) =>
+          new AssignedTargetingOption(
+            'geo1',
+            TARGETING_TYPE.GEO_REGION,
+            '',
+            '',
+            { displayName: geoTarget },
+          ),
+      ),
+    },
+  };
+
+  (params.allCampaigns ??= {})['1'] = [(campaign) => campaign];
+  (params.allInsertionOrders ??= {})['1'] = [(io) => io];
+  (params.allAdvertisers ??= []).push((advertiser) => advertiser);
+
+  params.fakeSpendAmount ??= 1000000;
+
+  const clientArgs = {
+    id,
+    idType: params.idType ? params.idType : IDType.ADVERTISER,
+    label: 'Test',
+  } satisfies ClientArgs;
+
+  return generateTestClient({
+    id,
+    allAssignedTargetingOptions,
+    clientArgs,
+    ...params,
+  });
+}
+
+describe('Matrix to CSV', () => {
+  let frontend: DisplayVideoFrontend;
+
+  beforeEach(() => {
+    setUp();
+    frontend = getFrontend();
+  });
+
+  it('Handles simple 2-d arrays', () => {
+    const matrix = [
+      ['a1', 'b1', 'c1'],
+      ['a2', 'b2', 'c2'],
+      ['a3', 'b3', 'c3'],
+    ];
+    expect(
+      frontend.matrixToCsv(matrix, {
+        category: 'dv360',
+        sheetId: 'a',
+        ruleName: 'rule1',
+        label: 'label',
+        currentTime: '2020-01-01T00:00:00.000Z',
+      }),
+    ).toEqual(
+      '"Category","Sheet ID","Label","Rule Name","Current Time","a1","b1","c1"\n"dv360","a","label","rule1","2020-01-01T00:00:00.000Z","a2","b2","c2"\n"dv360","a","label","rule1","2020-01-01T00:00:00.000Z","a3","b3","c3"',
+    );
+  });
+
+  it('Handles complex 2-d arrays', () => {
+    const matrix = [
+      ['Not another CSV function!'],
+      [`Famous last words, like "This format probably won't happen!"`],
+    ];
+    expect(
+      frontend.matrixToCsv(matrix, {
+        category: 'dv360',
+        sheetId: 'a',
+        ruleName: 'rule1',
+        label: 'label',
+        currentTime: '2020-01-01T00:00:00.000Z',
+      }),
+    ).toEqual(
+      `"Category","Sheet ID","Label","Rule Name","Current Time","Not another CSV function!"\n"dv360","a","label","rule1","2020-01-01T00:00:00.000Z","Famous last words, like """This format probably won't happen!""""`,
+    );
+  });
+});
+
+interface FakeFiles {
+  currentId: number;
+  drives: Record<string, GoogleAppsScript.Drive.Schema.File>;
+  folders: Record<string, GoogleAppsScript.Drive.Schema.File[]>;
+  files: Record<string, GoogleAppsScript.Drive.Schema.File>;
+  get(id: string): GoogleAppsScript.Drive.Schema.File;
+  list(): { items?: GoogleAppsScript.Drive.Schema.File[] };
+  list({ q }: { q?: string }): { items?: GoogleAppsScript.Drive.Schema.File[] };
+  insert(
+    schema: GoogleAppsScript.Drive.Schema.File,
+    file: GoogleAppsScript.Base.Blob,
+  ): GoogleAppsScript.Drive.Schema.File;
+}
+const fakeFiles: FakeFiles = {
+  currentId: 0,
+  drives: {},
+  folders: {},
+  files: {},
+  list({ q }: { q?: string } = {}) {
+    if (!q) {
+      return { items: undefined };
+    }
+    const title: string | null = (q.match(/title="([^"]+)"/) || [])[1];
+    return { items: this.folders[title] };
+  },
+  insert(schema: GoogleAppsScript.Drive.Schema.File) {
+    if (!schema.title) {
+      throw new Error('A schema title is expected.');
+    }
+    for (const p of schema.parents || []) {
+      (this.folders[p.id!] ??= []).push(schema);
+    }
+    schema.id = schema.id || String(++this.currentId);
+    this.files[schema.title] = schema;
+    return schema;
+  },
+  get(id: string) {
+    return this.drives[id];
+  },
+};
+
+describe('Export as CSV', () => {
+  let frontend: DisplayVideoFrontend;
+  let oldDrive: GoogleAppsScript.Drive;
+
+  beforeEach(() => {
+    setUp();
+    frontend = getFrontend();
+    oldDrive = Drive;
+    Drive.Files =
+      fakeFiles as unknown as GoogleAppsScript.Drive.Collection.FilesCollection;
+    const range1 = SpreadsheetApp.getActive().getActiveSheet().getRange('Z10');
+    const range2 = SpreadsheetApp.getActive().getActiveSheet().getRange('Z11');
+    SpreadsheetApp.getActive().setNamedRange('REPORT_LABEL', range1);
+    SpreadsheetApp.getActive().setNamedRange('DRIVE_ID', range2);
+    SpreadsheetApp.getActive()
+      .getRangeByName('REPORT_LABEL')!
+      .setValue('Acme Inc.');
+    SpreadsheetApp.getActive().getRangeByName('DRIVE_ID')!.setValue('123abc');
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date('January 1, 1970 00:00:00 GMT'));
+  });
+
+  afterEach(() => {
+    Drive = oldDrive;
+    jasmine.clock().uninstall();
+  });
+
+  it('saves the file', () => {
+    fakeFiles.drives['123abc'] = {
+      id: '123abc',
+      mimeType: FOLDER,
+      title: 'launch_monitor',
+    };
+    console.log(Utilities);
+    frontend.exportAsCsv('my check', [['it works!']]);
+    const folderId = fakeFiles.files['reports'];
+    expect(fakeFiles.folders[folderId.id!]).toEqual([
+      jasmine.objectContaining({
+        id: '2',
+        mimeType: 'text/plain',
+        parents: [{ id: '1' }],
+      }),
+    ]);
+
+    for (const value of [
+      'Acme Inc.',
+      'my check',
+      '1970-01-01T00:00:00.000Z.csv',
+    ]) {
+      expect(Object.keys(fakeFiles.files)[1].split('_')).toContain(value);
+    }
+  });
+});
+
+describe('Fill check values', () => {
+  let rules: RuleRange;
+  let frontend: DisplayVideoFrontend;
+
+  beforeEach(async () => {
+    setUp();
+    frontend = getFrontend(() => testData({}));
+    rules = new RuleRange([[]], frontend.client);
+    await frontend.initializeRules();
+  });
+  it('removes extra fields', async () => {
+    const noise = Array.from<string>({ length: 10 })
+      .fill('')
+      .map(() => Array.from<string>({ length: 10 }).fill('lorem ipsum'));
+    const sheet = getOrCreateSheet(RULE_SETTINGS_SHEET + ' - Insertion Order')!;
+    sheet.clear();
+    sheet.getRange(1, 1, noise.length, noise[0].length).setValues(noise);
+    await rules.fillRuleValues(geoTargetRule.definition);
+    expect((await rules.getValues())[0].length).toEqual(5);
+  });
+});
+
+describe('getMatrixOfResults', () => {
+  let frontend: DisplayVideoFrontend;
+
+  beforeEach(() => {
+    setUp();
+    frontend = getFrontend();
+  });
+
+  it('Provides 2-d array from a set of values with no fields.', async () => {
+    const result = frontend.getMatrixOfResults('value1', [equalTo(1, 1, {})]);
+    expect(result).toEqual([
+      ['value1', 'anomalous'],
+      ['1', 'false'],
+    ]);
+  });
+  it('Provides 2-d array from a set of values with fields.', async () => {
+    const result = frontend.getMatrixOfResults('value2', [
+      equalTo(1, 1, { test1: 'a', test2: 'b' }),
+    ]);
+    expect(result).toEqual([
+      ['value2', 'anomalous', 'test1', 'test2'],
+      ['1', 'false', 'a', 'b'],
+    ]);
+  });
+});
+
+describe('Partner view', () => {
+  let frontend: DisplayVideoFrontend;
+
+  beforeAll(() => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date('January 1, 1970 00:00:00 GMT'));
+  });
+
+  afterAll(() => {
+    jasmine.clock().uninstall();
+  });
+
+  beforeEach(async () => {
+    setUp({ level: 'Partner' });
+    const allAdvertisers: AdvertiserTemplateConverter[] = [
+      (advertiser) => {
+        advertiser.id = 'a1';
+        advertiser.displayName = 'Advertiser 1';
+
+        return advertiser;
+      },
+    ];
+    const allCampaigns: Record<string, CampaignTemplateConverter[]> = {
+      '1': [
+        (campaignTemplate) => {
+          campaignTemplate.id = 'c2';
+          campaignTemplate.displayName = 'Campaign 2';
+
+          return campaignTemplate;
+        },
+      ],
+    };
+    const allInsertionOrders: Record<
+      string,
+      InsertionOrderTemplateConverter[]
+    > = {
+      c2: [
+        (insertionOrderTemplate) => {
+          insertionOrderTemplate.id = 'io2';
+          insertionOrderTemplate.displayName = 'IO 2';
+          insertionOrderTemplate.campaignId = 'c2';
+          return insertionOrderTemplate;
+        },
+      ],
+    };
+    frontend = getFrontend(() =>
+      testData({
+        allCampaigns,
+        allAdvertisers,
+        allInsertionOrders,
+        idType: IDType.PARTNER,
+      }),
+    );
+  });
+
+  it('Has advertiser ID and name in settings', async () => {
+    await frontend.initializeRules();
+    const values = SpreadsheetApp.getActive()
+      .getSheetByName('Rule Settings - Insertion Order')
+      .getDataRange()
+      .getValues();
+    expect(values[2].slice(0, 4)).toEqual([
+      'ID',
+      'Insertion Order Name',
+      'Advertiser ID',
+      'Advertiser Name',
+    ]);
+    expect(values[4].slice(0, 4)).toEqual([
+      'io1',
+      'Insertion Order 1',
+      'a1',
+      'Advertiser 1',
+    ]);
+  });
+});
+
+describe('initializeRules', () => {
+  const allCampaigns: { [advertiserId: string]: CampaignTemplateConverter[] } =
+    {};
+  let frontend: DisplayVideoFrontend;
+
+  beforeEach(async () => {
+    setUp();
+    frontend = getFrontend(() => testData({ allCampaigns }));
+    jasmine.clock().install().mockDate(new Date('1970-03-01'));
+    await frontend.initializeRules();
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
+  it('creates a settings page', () => {
+    const sheet = getOrCreateSheet('Rule Settings - Insertion Order');
+    expect(sheet).toBeTruthy();
+  });
+});
+
+function setUp(
+  { level }: { level: 'Advertiser' | 'Partner' } = {
+    level: 'Advertiser',
+  },
+) {
+  mockAppsScript();
+  PropertiesService.getScriptProperties().setProperty('sheet_version', '5.0');
+  scaffoldSheetWithNamedRanges({ level });
+  const frontend = getFrontend(() => testData({ idType: IDType.PARTNER }));
+  spyOn(HELPERS, 'insertRows').and.callFake((range) => range);
+  spyOn(HELPERS, 'getSheetId').and.callFake(() => 'id1');
+  return frontend;
+}
+
+function scaffoldSheetWithNamedRanges(
+  { level }: { level: 'Advertiser' | 'Partner' } = {
+    level: 'Advertiser',
+  },
+) {
+  for (const [i, [constName, value]] of [
+    ['ENTITY_ID', '1'],
+    ['ID_TYPE', level],
+    ['EMAIL_LIST', ''],
+    ['LABEL', 'Acme Inc.'],
+  ].entries()) {
+    const range = SpreadsheetApp.getActive()
+      .getActiveSheet()
+      .getRange(`$A$${i + 1}`);
+    SpreadsheetApp.getActive().setNamedRange(constName, range);
+    SpreadsheetApp.getActive().getRangeByName(constName)!.setValue(value);
+  }
+}

--- a/dv360/src/tests/migrations_test.ts
+++ b/dv360/src/tests/migrations_test.ts
@@ -1,0 +1,68 @@
+import {
+  FakePropertyStore,
+  mockAppsScript,
+} from 'common/test_helpers/mock_apps_script';
+import { DisplayVideoFrontend, migrations } from '../frontend';
+import { PropertyStore } from 'common/types';
+import { Client, RuleRange } from '../client';
+import { scaffoldSheetWithNamedRanges } from 'common/tests/helpers';
+import { geoTargetRule } from '../rules';
+import { ClientInterface } from '../types';
+import {
+  AssignedTargetingOption,
+  Campaign,
+  InsertionOrder,
+} from 'dv360_api/dv360_resources';
+import {
+  PACING_PERIOD,
+  PACING_TYPE,
+  TARGETING_TYPE,
+} from 'dv360_api/dv360_types';
+
+describe('Migrations: upgrades', () => {
+  beforeEach(() => {
+    mockAppsScript();
+    scaffoldSheetWithNamedRanges();
+  });
+  it('to v3.0', async () => {
+    const sheet = SpreadsheetApp.getActive().insertSheet(
+      'Rule Settings - Campaign',
+    );
+    PropertiesService.getScriptProperties().setProperty('sheet_version', '2.0');
+    sheet
+      .getRange(3, 1, 1, 4)
+      .setValues([
+        ['ID', 'Campaign Name', 'Geo Targets', 'Excluded Geo Targets'],
+      ]);
+    const frontend = getFrontend('3.0');
+
+    frontend.migrate();
+
+    const header: string[] = sheet.getRange(3, 1, 1, 4).getValues()[0];
+    expect(header.findIndex((c) => c === 'Geo Targets')).toEqual(-1);
+    expect(
+      header.findIndex((c) => c === 'Allowed Geo Targets'),
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      header.findIndex((c) => c === 'Excluded Geo Targets'),
+    ).toBeGreaterThanOrEqual(0);
+  });
+});
+
+function getFrontend(
+  version: string,
+  properties: PropertyStore = new FakePropertyStore(),
+  overrides: (client: ClientInterface) => ClientInterface = (client) => client,
+) {
+  return new DisplayVideoFrontend({
+    ruleRangeClass: RuleRange,
+    rules: [geoTargetRule],
+    version,
+    clientInitializer(clientArgs, properties) {
+      const client = new Client(clientArgs, properties);
+      return overrides(client);
+    },
+    migrations,
+    properties,
+  });
+}

--- a/dv360/src/tests/migrations_test.ts
+++ b/dv360/src/tests/migrations_test.ts
@@ -8,16 +8,6 @@ import { Client, RuleRange } from '../client';
 import { scaffoldSheetWithNamedRanges } from 'common/tests/helpers';
 import { geoTargetRule } from '../rules';
 import { ClientInterface } from '../types';
-import {
-  AssignedTargetingOption,
-  Campaign,
-  InsertionOrder,
-} from 'dv360_api/dv360_resources';
-import {
-  PACING_PERIOD,
-  PACING_TYPE,
-  TARGETING_TYPE,
-} from 'dv360_api/dv360_types';
 
 describe('Migrations: upgrades', () => {
   beforeEach(() => {

--- a/sa360/appsscript.json
+++ b/sa360/appsscript.json
@@ -16,7 +16,8 @@
     "https://www.googleapis.com/auth/drive.file",
     "https://www.googleapis.com/auth/drive.readonly",
     "https://www.googleapis.com/auth/adwords",
-    "https://www.googleapis.com/auth/script.container.ui"
+    "https://www.googleapis.com/auth/script.container.ui",
+    "https://www.googleapis.com/auth/script.send_mail"
   ],
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8"

--- a/sa360/src/client.ts
+++ b/sa360/src/client.ts
@@ -107,14 +107,13 @@ export class Client implements ClientInterface {
    */
   async validate() {
     type Executor = RuleExecutor<SearchAdsClientTypes>;
-    const thresholds: Array<[Executor, () => ExecutorResult]> = Object.values(
-      this.ruleStore,
-    ).reduce(
-      (prev, rule) => {
-        return [...prev, [rule, rule.run.bind(rule)]];
-      },
-      [] as Array<[Executor, () => ExecutorResult]>,
-    );
+    const thresholds: Array<[Executor, () => Promise<ExecutorResult>]> =
+      Object.values(this.ruleStore).reduce(
+        (prev, rule) => {
+          return [...prev, [rule, rule.run.bind(rule)]];
+        },
+        [] as Array<[Executor, () => ExecutorResult]>,
+      );
     const rules: Record<string, Executor> = {};
     const results: Record<string, ExecutorResult> = {};
     for (const [rule, thresholdCallable] of thresholds) {

--- a/sa360/yarn.lock
+++ b/sa360/yarn.lock
@@ -484,23 +484,7 @@
   resolved "https://registry.yarnpkg.com/@types/debounce/-/debounce-1.2.4.tgz#cb7e85d9ad5ababfac2f27183e8ac8b576b2abb3"
   integrity sha512-jBqiORIzKDOToaF63Fm//haOCHuwQuLa2202RK4MozpA6lh93eCBc+/8+wZn5OzjJt3ySdc+74SXWXB55Ewtyw==
 
-"@types/eslint-scope@^3.7.3":
-  version "3.7.7"
-  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"
-  integrity sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==
-  dependencies:
-    "@types/eslint" "*"
-    "@types/estree" "*"
-
-"@types/eslint@*":
-  version "8.56.10"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.56.10.tgz#eb2370a73bf04a901eeba8f22595c7ee0f7eb58d"
-  integrity sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==
-  dependencies:
-    "@types/estree" "*"
-    "@types/json-schema" "*"
-
-"@types/estree@*", "@types/estree@1.0.5", "@types/estree@^1.0.0", "@types/estree@^1.0.5":
+"@types/estree@1.0.5", "@types/estree@^1.0.0", "@types/estree@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
@@ -569,7 +553,7 @@
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-5.1.4.tgz#0de3f6ca753e10d1600ce1864ae42cfd47cf9924"
   integrity sha512-px7OMFO/ncXxixDe1zR13V1iycqWae0MxTaw62RpFlksUi5QuNWgQJFkTQjIOvrmutJbI7Fp2Y2N1F6D2R4G6w==
 
-"@types/json-schema@*", "@types/json-schema@^7.0.8":
+"@types/json-schema@^7.0.8":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
@@ -1874,10 +1858,18 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^5.0.0, enhanced-resolve@^5.17.0, enhanced-resolve@^5.7.0:
+enhanced-resolve@^5.0.0, enhanced-resolve@^5.7.0:
   version "5.17.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz#d037603789dd9555b89aaec7eb78845c49089bc5"
   integrity sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
+enhanced-resolve@^5.17.1:
+  version "5.17.1"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz#67bfbbcc2f81d511be77d686a90267ef7f898a15"
+  integrity sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -4271,16 +4263,7 @@ streamx@^2.15.0, streamx@^2.18.0:
   optionalDependencies:
     bare-events "^2.2.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4305,14 +4288,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4727,12 +4703,11 @@ webpack-sources@^3.1.1, webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@^5.75.0:
-  version "5.92.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.92.1.tgz#eca5c1725b9e189cffbd86e8b6c3c7400efc5788"
-  integrity sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==
+webpack@^5.94.0:
+  version "5.94.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.94.0.tgz#77a6089c716e7ab90c1c67574a28da518a20970f"
+  integrity sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==
   dependencies:
-    "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^1.0.5"
     "@webassemblyjs/ast" "^1.12.1"
     "@webassemblyjs/wasm-edit" "^1.12.1"
@@ -4741,7 +4716,7 @@ webpack@^5.75.0:
     acorn-import-attributes "^1.9.5"
     browserslist "^4.21.10"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.17.0"
+    enhanced-resolve "^5.17.1"
     es-module-lexer "^1.2.1"
     eslint-scope "5.1.1"
     events "^3.2.0"
@@ -4790,7 +4765,7 @@ wordwrapjs@^5.1.0:
   resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-5.1.0.tgz#4c4d20446dcc670b14fa115ef4f8fd9947af2b3a"
   integrity sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -4803,15 +4778,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Version 2.1 PR - 

We never actually updated to version 2, so I added some breaking changes.

-----

## Basic
- Bumped "sheet_version" to 2.1

## Geotargets - potentially breaking change
- Geotargets now have an error value instead of "0" or "1", explaining why something is happening.
- Re-named "Geotargets" parameter to "Allowed Targets" and added a new "Required Targets" field. Allowed Targets can be used but all targets in campaigns must be a subset. Required targets must be used or an error will be thrown.

## Re-added Advertiser ID & Name to repository
- We lost this feature request in the move over to GitHub.

## Re-added missing end-to-end tests
- We lost integration tests in the move over to GitHub. There are some more that haven't been ported over yet. The ones implemented so far cover all newly added code.

## Quality of Life
- Split out some of the deeply nested functional code (maps/reduces) for better debugging.

## Bugs
- Fixed a debugging issue in DV360 where the async wrapper was not on the main function, causing unpredictable termination behavior.
- Removed a requirement to have a numberFormat on an empty row, which, paired with the first bug, was causing silent failures of the launch. This was more obvious once the Line Item budget rule was introduced because it never ran.

-----
- [x] Ran and tested SA360
- [x] Ran and tested DV360

