### PR TITLE
Bug Fix: Adding decodeURI() to unescape __dirname in webpack.config.mjs

### DIFF
--- a/ts/sa360/webpack.config.mjs
+++ b/ts/sa360/webpack.config.mjs
@@ -18,7 +18,7 @@
 import GasPlugin from 'gas-webpack-plugin';
 import TsConfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
 import path from 'path';
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const __dirname = decodeURI(path.dirname(new URL(import.meta.url).pathname));
 
 export default {
   context: __dirname,


### PR DESCRIPTION
When passed through the new URL() constructor, any URL-unsafe characters within the path are encoded—including spaces. For example, "/Users/varunpramanik/Some Folder/" will be rendered to "/Users/varunpramanik/Some%20Folder/". Webpack then proceeds to look for this escaped path, finds it doesn't exist, and throws errors. An outermost decodeURI() fixes this issue.